### PR TITLE
Feature/day 2 summarystats tickertype

### DIFF
--- a/components/SummaryStats/SummaryStats.module.scss
+++ b/components/SummaryStats/SummaryStats.module.scss
@@ -1,11 +1,26 @@
+.wrapper {
+  width: 90%;
+  margin: 4rem auto;
+  max-width: 500px;
+  border-top: 2px solid #d3d3d357;
+  padding: 16px 0;
+}
+
+.title {
+  text-align: center;
+}
+
 .summaryStats {
   border-collapse: collapse;
   width: 100%;
+
   caption {
     font-weight: bold;
     text-transform: uppercase;
     line-height: 2;
     font-size: 1.3rem;
+    background-color: blue;
+    color: white;
   }
 
   tr {

--- a/components/SummaryStats/SummaryStats.tsx
+++ b/components/SummaryStats/SummaryStats.tsx
@@ -2,8 +2,28 @@ import React from 'react'
 import { summaryStats } from './mockData' // todo: replace dummy data with api data
 import { toUSD, toUsNum } from '../../utils/numbers'
 import styles from './SummaryStats.module.scss'
+import { tickerSelections$ } from '../TickerTypeahead'
+import { bind } from '@react-rxjs/core'
+import { switchMap } from 'rxjs/operators'
+import { ajax } from 'rxjs/ajax'
+
+/**
+ * 
+ */
+ const [useSummaryStats, summaryStats$] = bind(
+  tickerSelections$.pipe(
+    switchMap(
+      (ticker) => ajax.getJSON(`http://localhost:3000/summary-stats/${ticker}`)
+      // Todo -> add catchError
+    )
+  ),
+  {} // as SummaryStats -> our interface type
+)
+
 
 export default function SummaryStats() {
+  // uncomment when  backend is hooked up :) 
+  // const summaryStats = useSummaryStats();
 
   if(!summaryStats) {
     return (<h2>Search a stock ticker</h2>)
@@ -35,7 +55,7 @@ export default function SummaryStats() {
   const rows = () => {
     return Object.entries(config).map(([key, entry]) => {
       return (
-        <tr>
+        <tr key={key}>
           <th>{entry.label}</th>
           <td>{entry.data}</td>
         </tr>
@@ -44,7 +64,7 @@ export default function SummaryStats() {
   }
 
   return (
-    <div>
+    <div className={styles.wrapper}>
       <h2>{summaryStats.companyName}</h2>
       <table className={styles.summaryStats}>
         <caption>Summary</caption>

--- a/components/TickerTypeahead/TickerTypeahead.module.css
+++ b/components/TickerTypeahead/TickerTypeahead.module.css
@@ -1,3 +1,0 @@
-.visuallyHide {
-  display: none;
-}

--- a/components/TickerTypeahead/TickerTypeahead.module.scss
+++ b/components/TickerTypeahead/TickerTypeahead.module.scss
@@ -1,0 +1,54 @@
+.visuallyHide {
+  display: none;
+}
+
+.search {
+  width: 80%;
+  margin: auto;
+  max-width: 300px;
+  position: relative;
+
+  input {
+    padding: 16px 8px;
+    width: 100%;
+    border: 2px solid #d5d2d2;
+    appearance: none;
+    border-style: solid;
+    border-radius: 4px;
+    font-size: 1.2rem;
+
+    &:focus {
+      outline-color: royalblue;
+    }
+  }
+}
+
+.dropdown {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  border: 2px solid #d5d2d2;
+  border-radius: 4px;
+  border-top: none;
+  position: absolute;
+  width: 100%;
+  background-color: white;
+  overflow-y: scroll;
+  max-height: 300px;
+
+  &__option {
+    appearance: none;
+    border: none;
+    background: none;
+    display: block;
+    padding: 12px 8px;
+    width: 100%;
+    text-align: left;
+    font-size: 1rem;
+
+    &:hover {
+      background-color: blue;
+      color: white;
+    }
+  }
+}

--- a/components/TickerTypeahead/TickerTypeahead.tsx
+++ b/components/TickerTypeahead/TickerTypeahead.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { catchError, debounceTime, map, switchMap } from "rxjs/operators"
 import { of } from "rxjs"
-import styles from "./TickerTypeahead.module.css"
+import styles from "./TickerTypeahead.module.scss"
 // import { mockResults } from "./mockResults"
 import { createSignal } from "@react-rxjs/utils"
 import { bind } from "@react-rxjs/core"
@@ -14,9 +14,29 @@ interface TickerOption {
   label: string;
 }
 
+  // dummy data - delete when backend apis are set up
+  let options = [
+    {
+      value: 'nyse:a',
+      label: 'NYSE:A',
+    },
+    {
+      value: 'nyse:f',
+      label: 'NYSE:F',
+    },
+    {
+      value: 'nyse:v',
+      label: 'NYSE:V',
+    },
+    {
+      value: 'nyse:b',
+      label: 'NYSE:B',
+    }
+  ]
+
 const [useOptions, options$] = bind(
   searchInputs$.pipe(
-    debounceTime(100),
+    debounceTime(300),
     switchMap(
       // For mock results ->
       // of(input.length ? mockResults.filter((result) => result.symbol.toLowerCase().startsWith(input)) : [] 
@@ -32,7 +52,7 @@ const [useOptions, options$] = bind(
     [] as TickerOption[]
 )
 
-const [tickerSelections$, onCompanySelection] = createSignal<string>()
+const [tickerSelections$, onTickerSelection] = createSignal<string>()
 
 /**
  * We export out tickerSelections to the rest of the app
@@ -42,43 +62,43 @@ const [tickerSelections$, onCompanySelection] = createSignal<string>()
  */
 export { tickerSelections$ } 
 
-/**
- * This would be defined 
- */
-const [useSummaryStats, summaryStats$] = bind(
-  tickerSelections$.pipe(
-    switchMap(
-      (ticker) => ajax.getJSON(`http://localhost:3000/summary-stats/${ticker}`)
-      // Todo -> add catchError
-    )
-  ),
-  {} // as SummaryStats -> our interface type
-)
 
 export default function TickerTypeahead() {
-  const options = useOptions()
+  // uncomment when background is hooked up
+  // const options = useOptions()
+  
+  const optionsList = () => {
+    return (
+      <ul className={styles.dropdown}>
+        {options.map((option) => (
+          <li key={option.value}>
+            <button className={styles.dropdown__option} onClick={() => onTickerSelection(option.value)}>
+              { option.label }
+            </button>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
   return (
-    <>
+    <form className={styles.search}>
       <div>
         <label className={styles.visuallyHide} htmlFor="ticker-select">
           Ticker Select
         </label>
         <input
+          className={styles.search}
           id="ticker-select"
           type="search"
-          placeholder="Search for stock ticker"
-          onChange={(e) => {
-            onNextSearchInput(e.target.value)
-          }}
+          placeholder="Search a stock ticker..."
+          // uncomment when backend is hooked up
+          // onChange={(e) => {
+          //   onNextSearchInput(e.target.value)
+          // }}
         />
       </div>
-      <div>
-        {options.map((option) => (
-          <div key={option.value} onClick={() => onCompanySelection(option.value)}>
-            { option.label }
-          </div>
-        ))}
-      </div>
-    </>
+      {options.length ? optionsList() : ''}
+    </form>
   )
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,19 +1,9 @@
 .container {
   min-height: 100vh;
-  padding: 0 0.5rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
 }
 
 .mainContainer {
-  padding: 5rem 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  padding: 3rem 0;
 }
 
 .mainLayout {
@@ -62,7 +52,7 @@
 .title {
   margin: 0;
   line-height: 1.15;
-  font-size: 4rem;
+  font-size: 2rem;
 }
 
 .title,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,7 @@ body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
     Helvetica Neue, sans-serif;
+  font-size: 12px;
 }
 
 a {
@@ -13,4 +14,10 @@ a {
 
 * {
   box-sizing: border-box;
+}
+
+@media screen and (min-width: 768px) {
+  html {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
# Description
* Styling on whole app as well as improve the structure of the tickertypeahead html (could use aria-roles -- will add later)
* Moves the summary stats hook into the summary stats doc

### Note
Everything is still very static  - in the first screen shot below, i just removed the ul 

# To Do
1. Uncomment a bunch of stuff once the backend api stuff is complete
2. Add in a 'error state' if there is no ticker found 

# Screen Shot
![image](https://user-images.githubusercontent.com/62032574/113219066-aa779480-924e-11eb-8fa7-4686a66911c9.png)

![image](https://user-images.githubusercontent.com/62032574/113218960-70a68e00-924e-11eb-96d1-a9ed1901e0a2.png)
